### PR TITLE
Skip webserver for todos in prod

### DIFF
--- a/todos/synthetics-tests/hooks.journey.ts
+++ b/todos/synthetics-tests/hooks.journey.ts
@@ -4,10 +4,13 @@ import { Server as StaticServer } from 'node-static';
 
 let srv: Server;
 
-beforeAll(async () => {
+beforeAll(async ({env}) => {
     const loc = (__dirname + "/../app");
     const ss = new(StaticServer)(loc);
 
+    if (env === "production") {
+        return
+    }
     return new Promise(isUp => {
         console.log(`Serving static app from ${loc}`)
         srv = createServer((req, res) => {


### PR DESCRIPTION
There's no reason to run the webserver under heartbeat.