### PR TITLE
Add mfa-checkout monitor

### DIFF
--- a/e-commerce/.synthetics/project.json
+++ b/e-commerce/.synthetics/project.json
@@ -1,0 +1,5 @@
+{
+  "url": "http://localhost:5602/uva",
+  "space": "default",
+  "project": "examplelocal"
+}

--- a/e-commerce/demo.journey.js
+++ b/e-commerce/demo.journey.js
@@ -1,115 +1,95 @@
-const { journey, step, expect } = require('@elastic/synthetics');
-
-const URL = 'https://elastic-synthetics-demo-ecommerce.vercel.app/';
-
-const navigateToProductDetail = (page, params) => {
-  step('visit landing page', async () => {
-    await page.goto(params.url || URL, { waitUntil: 'networkidle' });
-    // check to make sure all products are loaded
-    const productImages = await page.$$('.card img');
-    expect(productImages.length).toBe(9);
-  });
-
-  step('navigate to product detail page', async () => {
-    const productImages = await page.$$('.card img');
-    const randomCard = Math.floor(Math.random() * productImages.length);
-    const product = productImages[randomCard];
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: 'networkidle' }),
-      product.click(),
-    ]);
-  });
-};
-
-journey(
-  { name: 'Browse products and recommendations flow', tags: ['browse'] },
-  ({ page, params }) => {
-    navigateToProductDetail(page, params);
-
-    step('look for recommendations', async () => {
-      const recommendationsNode = await page.$('text=Products you might like');
-      expect(recommendationsNode).toBeDefined();
-      // Waits for recommendation product cards
-      const recommendedProducts = await page.$$('.container .card');
-      expect(recommendedProducts.length).toBe(4);
-    });
-  }
-);
-
-journey({ name: 'Delete cart items', tags: ['cart'] }, ({ page, params }) => {
-  navigateToProductDetail(page, params);
-
-  step('Add items to cart', async () => {
-    await page.selectOption('select[name="quantity"]', '2');
-    await Promise.all([
-      page.waitForNavigation({
-        url: /cart/,
-        waitUntil: 'networkidle',
-      }),
-      page.click('text=Add to Cart'),
-    ]);
-  });
-
-  step('empty cart items', async () => {
-    const headline = await page.$('.container h3');
-    expect(await headline.textContent()).toContain(
-      '1 items in your Shopping Cart'
-    );
-    await Promise.all([
-      page.waitForNavigation({ waitUntil: 'networkidle' }),
-      page.click('text=Empty cart'),
-    ]);
-  });
-
-  step('verify empty shopping cart', async () => {
-    await Promise.all([
-      page.waitForNavigation({ url: /cart/, waitUntil: 'networkidle' }),
-      page.click('text=View Cart'),
-    ]);
-    await page.waitForSelector('.container');
-    const headline = await page.$('.container h3');
-    expect(await headline.textContent()).toContain(
-      'Your shopping cart is empty'
-    );
-  });
-});
-
-journey(
-  { name: 'Product Checkout flow', tags: ['checkout'] },
-  ({ page, params }) => {
-    navigateToProductDetail(page, params);
-
-    step('add product to cart', async () => {
-      await page.selectOption('select[name="quantity"]', '3');
-      await Promise.all([
-        page.waitForNavigation({
-          url: /cart/,
-          waitUntil: 'networkidle',
-        }),
-        page.click('text=Add to Cart'),
-      ]);
-    });
-
-    step('check cart items and place the order', async () => {
-      const headline = await page.$('.container h3');
-      expect(await headline.textContent()).toContain(
-        '1 items in your Shopping Cart'
-      );
-      await Promise.all([
-        page.waitForNavigation({
-          url: /checkout/,
-          waitUntil: 'networkidle',
-        }),
-        page.click('text=Place your order →'),
-      ]);
-    });
-
-    step('verify the order details', async () => {
-      expect(page.url()).toContain('checkout');
-      const containerNode = await page.$('.container .row');
-      const content = await containerNode.textContent();
-      expect(content).toContain('Your order is complete');
-      expect(content).toContain('Order Confirmation');
-    });
-  }
-);
+// const { journey, step, expect } = require('@elastic/synthetics');
+// const { navigateToProductDetail } = require("./utils");
+// 
+// journey(
+//   { name: 'Browse products and recommendations flow', tags: ['browse'] },
+//   ({ page, params }) => {
+//     navigateToProductDetail(page, params);
+// 
+//     step('look for recommendations', async () => {
+//       const recommendationsNode = await page.$('text=Products you might like');
+//       expect(recommendationsNode).toBeDefined();
+//       // Waits for recommendation product cards
+//       const recommendedProducts = await page.$$('.container .card');
+//       expect(recommendedProducts.length).toBe(4);
+//     });
+//   }
+// );
+// 
+// journey({ name: 'Delete cart items', tags: ['cart'] }, ({ page, params }) => {
+//   navigateToProductDetail(page, params);
+// 
+//   step('Add items to cart', async () => {
+//     await page.selectOption('select[name="quantity"]', '2');
+//     await Promise.all([
+//       page.waitForNavigation({
+//         url: /cart/,
+//         waitUntil: 'networkidle',
+//       }),
+//       page.click('text=Add to Cart'),
+//     ]);
+//   });
+// 
+//   step('empty cart items', async () => {
+//     const headline = await page.$('.container h3');
+//     expect(await headline.textContent()).toContain(
+//       '1 items in your Shopping Cart'
+//     );
+//     await Promise.all([
+//       page.waitForNavigation({ waitUntil: 'networkidle' }),
+//       page.click('text=Empty cart'),
+//     ]);
+//   });
+// 
+//   step('verify empty shopping cart', async () => {
+//     await Promise.all([
+//       page.waitForNavigation({ url: /cart/, waitUntil: 'networkidle' }),
+//       page.click('text=View Cart'),
+//     ]);
+//     await page.waitForSelector('.container');
+//     const headline = await page.$('.container h3');
+//     expect(await headline.textContent()).toContain(
+//       'Your shopping cart is empty'
+//     );
+//   });
+// });
+// 
+// journey(
+//   { name: 'Product Checkout flow', tags: ['checkout'] },
+//   ({ page, params }) => {
+//     navigateToProductDetail(page, params);
+// 
+//     step('add product to cart', async () => {
+//       await page.selectOption('select[name="quantity"]', '3');
+//       await Promise.all([
+//         page.waitForNavigation({
+//           url: /cart/,
+//           waitUntil: 'networkidle',
+//         }),
+//         page.click('text=Add to Cart'),
+//       ]);
+//     });
+// 
+//     step('check cart items and place the order', async () => {
+//       const headline = await page.$('.container h3');
+//       expect(await headline.textContent()).toContain(
+//         '1 items in your Shopping Cart'
+//       );
+//       await Promise.all([
+//         page.waitForNavigation({
+//           url: /checkout/,
+//           waitUntil: 'networkidle',
+//         }),
+//         page.click('text=Place your order →'),
+//       ]);
+//     });
+// 
+//     step('verify the order details', async () => {
+//       expect(page.url()).toContain('checkout');
+//       const containerNode = await page.$('.container .row');
+//       const content = await containerNode.textContent();
+//       expect(content).toContain('Your order is complete');
+//       expect(content).toContain('Order Confirmation');
+//     });
+//   }
+// );

--- a/e-commerce/mfa.journey.js
+++ b/e-commerce/mfa.journey.js
@@ -1,0 +1,96 @@
+const { journey, step, expect } = require('@elastic/synthetics');
+const totp = require("totp-generator");
+const { navigateToProductDetail } = require("./utils");
+const jsQR = require("jsqr");
+const PNGReader = require("png.js");
+
+const pngToByteArray = (pngData) => {
+  const rgbArr = new Uint8ClampedArray(pngData.width * pngData.height * 4);
+  for (let y = 0; y < pngData.height; y++) {
+    for (let x = 0; x < pngData.width; x++) {
+      const pixelData = pngData.getPixel(x, y);
+
+      rgbArr[(y * pngData.width + x) * 4 + 0] = pixelData[0];
+      rgbArr[(y * pngData.width + x) * 4 + 1] = pixelData[1];
+      rgbArr[(y * pngData.width + x) * 4 + 2] = pixelData[2];
+      rgbArr[(y * pngData.width + x) * 4 + 3] = pixelData[3];
+    }
+  }
+
+  return rgbArr;
+}
+
+const decodeQrCode = (buffer) => {
+  return new Promise((resolve, reject) => {
+    const reader = new PNGReader(buffer);
+    reader.parse((err, png) => {
+        if (err) reject(err)
+        return resolve({
+            rgbArr: pngToByteArray(png),
+            width: png.getWidth(),
+            height: png.getHeight(),
+        });
+    });
+  });
+}
+
+export const generateTotp = (value, intervalSeconds = 90) => {
+    return totp(value, {
+        digits: 6,
+        period: intervalSeconds,
+        timestamp: Date.now()
+    });
+}
+
+journey("mfa-checkout", ({ page, params }) => {
+  let seed = null;
+
+  step("setup MFA auth", async () => {
+      await page.goto(params.url);
+      await page.click("text=Set up MFA")
+      await page.click("text=Enable MFA")
+      const qrBuffer = await page.locator("#qr-code").screenshot()
+      const qrImg = await decodeQrCode(qrBuffer);
+      seed = jsQR(qrImg.rgbArr, qrImg.width, qrImg.height).data;
+  });
+
+  navigateToProductDetail(page, params);
+
+  step('Add items to cart', async () => {
+    await page.selectOption('select[name="quantity"]', '2');
+    await Promise.all([
+      page.waitForNavigation({
+        url: /cart/,
+        waitUntil: 'networkidle',
+      }),
+      page.click('text=Add to Cart'),
+    ]);
+  });
+
+  step('check cart items and place the order', async () => {
+    const headline = await page.$('.container h3');
+    expect(await headline.textContent()).toContain(
+      '1 items in your Shopping Cart'
+    );
+    await Promise.all([
+      page.waitForNavigation({
+        url: /mfa-auth/,
+        waitUntil: 'networkidle',
+      }),
+      page.click('text=Place your order →'),
+    ]);
+  });
+
+  step('Enter MFA', async () => {
+    await page.locator("input[name=mfa]").fill(generateTotp(seed));
+    await page.keyboard.press("Enter");
+  });
+
+  step('verify the order details', async () => {
+    expect(page.url()).toContain('checkout');
+    const containerNode = await page.$('.container .row');
+    const content = await containerNode.textContent();
+    expect(content).toContain('Your order is complete');
+    expect(content).toContain('Order Confirmation');
+  });
+});

--- a/e-commerce/package.json
+++ b/e-commerce/package.json
@@ -6,6 +6,9 @@
     "test": "npx elastic-synthetics ."
   },
   "dependencies": {
-    "@elastic/synthetics": "^1.0.0-beta"
+    "@elastic/synthetics": "^1.0.0-beta.31",
+    "jsqr": "^1.4.0",
+    "png.js": "^0.2.1",
+    "totp-generator": "^0.0.13"
   }
 }

--- a/e-commerce/synthetics.config.js
+++ b/e-commerce/synthetics.config.js
@@ -1,8 +1,15 @@
-const config = {
-  params: {
-    url: 'https://elastic-synthetics-demo-ecommerce.vercel.app/',
-  },
-  playwrightOptions: {},
+module.exports = {
+    params: {
+        url: 'https://synthetics-ecommerce-demo-mfa.vercel.app',
+    },
+    playwrightOptions: {
+        ignoreHTTPSErrors: false,
+    },
+    /**
+     * Configure global monitor settings
+     */
+    monitor: {
+        schedule: 10,
+        locations: ['us_central'],
+    },
 };
-
-module.exports = config;

--- a/e-commerce/utils.js
+++ b/e-commerce/utils.js
@@ -1,0 +1,22 @@
+const { step, expect } = require('@elastic/synthetics');
+
+const URL = 'https://elastic-synthetics-demo-ecommerce.vercel.app/';
+
+export const navigateToProductDetail = (page, params) => {
+  step('visit landing page', async () => {
+    await page.goto(params.url || URL, { waitUntil: 'networkidle' });
+    // check to make sure all products are loaded
+    const productImages = await page.$$('.card img');
+    expect(productImages.length).toBe(9);
+  });
+
+  step('navigate to product detail page', async () => {
+    const productImages = await page.$$('.card img');
+    const randomCard = Math.floor(Math.random() * productImages.length);
+    const product = productImages[randomCard];
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'networkidle' }),
+      product.click(),
+    ]);
+  });
+};


### PR DESCRIPTION
# Summary

This adds an example for folks to be able to run tests that use the e-commerce example's new MFA features.

I did have to add a `project.json` file for this one to work with `push` (although it will be overriden when users pass CLI options).

Ideas on how to better deal with having to have a `project.json` are welcome.

I also had to do some other minor version changes for it to work appropriately for push.