### PR TITLE
Update workflows, fix broken node version

### DIFF
--- a/.github/workflows/advanced-examples-run-synthetics.yml
+++ b/.github/workflows/advanced-examples-run-synthetics.yml
@@ -13,17 +13,16 @@ jobs:
         working-directory: ./advanced-examples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install
       - run: "SYNTHETICS_JUNIT_FILE='junit-synthetics.xml' npx @elastic/synthetics . --reporter=junit"
         continue-on-error: true
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: '**/junit-*.xml'
-          fail_on: 'test failures'
+          junit_files: '**/junit-*.xml'
           check_name: Elastic Synthetics Tests

--- a/.github/workflows/todos-run-synthetics.yml
+++ b/.github/workflows/todos-run-synthetics.yml
@@ -13,17 +13,16 @@ jobs:
         working-directory: ./todos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install
       - run: "SYNTHETICS_JUNIT_FILE='junit-synthetics.xml' npx @elastic/synthetics . --reporter=junit"
         continue-on-error: true
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/junit-*.xml'
-          fail_on: 'test failures'
           check_name: Elastic Synthetics Tests

--- a/todos/.github/workflows/run-synthetics.yml
+++ b/todos/.github/workflows/run-synthetics.yml
@@ -10,17 +10,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - run: npm install
       - run: "SYNTHETICS_JUNIT_FILE='junit-synthetics.xml' npx @elastic/synthetics . --reporter=junit"
         continue-on-error: true
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.19
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: '**/junit-*.xml'
-          fail_on: 'test failures'
           check_name: Elastic Synthetics Tests


### PR DESCRIPTION
One of our actions, probably `checkout`, was on an old version and used an ancient version of node (12). This updates that and other workflows. If this passes we should update the project template in `@elastic/synthetics`. We should consider publishing our own actions as well in the future.