### PR TITLE
Remove continue on error for GH actions

### DIFF
--- a/.github/workflows/advanced-examples-run-synthetics.yml
+++ b/.github/workflows/advanced-examples-run-synthetics.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: 18
       - run: npm install
       - run: "SYNTHETICS_JUNIT_FILE='junit-synthetics.xml' npx @elastic/synthetics . --reporter=junit"
-        continue-on-error: true
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/todos-run-synthetics.yml
+++ b/.github/workflows/todos-run-synthetics.yml
@@ -19,7 +19,6 @@ jobs:
           node-version: 18
       - run: npm install
       - run: "SYNTHETICS_JUNIT_FILE='junit-synthetics.xml' npx @elastic/synthetics . --reporter=junit"
-        continue-on-error: true
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/advanced-examples/.github/workflows/run-synthetics.yml
+++ b/advanced-examples/.github/workflows/run-synthetics.yml
@@ -16,7 +16,6 @@ jobs:
           node-version: 16
       - run: npm install
       - run: "SYNTHETICS_JUNIT_FILE='junit-synthetics.xml' npx @elastic/synthetics . --reporter=junit"
-        continue-on-error: true
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1.19
         if: always()


### PR DESCRIPTION
We have been using workflows wrong, before #27  we had the junit action exit with a bad status code. Rather, the step before should fail with that step merely doing reporting. v1 of the junit workflow supported our previous incorrect method, v2 recommends against it.

You can see an example of this working with a failing test in #30 