### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/advanced-examples-run-synthetics.yml
+++ b/.github/workflows/advanced-examples-run-synthetics.yml
@@ -8,6 +8,7 @@ on:
     - cron: '* 0 * * *'
 permissions:
   contents: read
+  checks: write
 
 jobs:
   test:

--- a/.github/workflows/advanced-examples-run-synthetics.yml
+++ b/.github/workflows/advanced-examples-run-synthetics.yml
@@ -6,6 +6,9 @@ on:
     branches: [main, master]
   schedule:
     - cron: '* 0 * * *'
+permissions:
+  contents: read
+
 jobs:
   test:
     defaults:

--- a/.github/workflows/cloud-push-synthetics.yml
+++ b/.github/workflows/cloud-push-synthetics.yml
@@ -5,6 +5,9 @@ on:
       #    branches: [main, master]
 env:
   SYNTHETICS_API_KEY: ${{ secrets.SYNTHETICS_API_KEY }}
+permissions:
+  contents: read
+
 jobs:
   push-monitors:
     defaults:

--- a/.github/workflows/todos-run-synthetics.yml
+++ b/.github/workflows/todos-run-synthetics.yml
@@ -8,6 +8,7 @@ on:
     - cron: '* 0 * * *'
 permissions:
   contents: read
+  checks: write
 
 jobs:
   test:

--- a/.github/workflows/todos-run-synthetics.yml
+++ b/.github/workflows/todos-run-synthetics.yml
@@ -6,6 +6,9 @@ on:
     branches: [main, master]
   schedule:
     - cron: '* 0 * * *'
+permissions:
+  contents: read
+
 jobs:
   test:
     defaults:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
